### PR TITLE
Bug 1203146 - Pulse Actions throws an unreadable exception when the proper env variables are not set up

### DIFF
--- a/pulse_actions/authentication.py
+++ b/pulse_actions/authentication.py
@@ -1,0 +1,25 @@
+import os
+
+
+class AuthenticationError(Exception):
+    pass
+
+
+def get_user_and_password():
+    """
+    Retrieve user and password environment variables.
+
+    Raise AuthenticationError if either aren't defined.
+    """
+
+    user = os.environ.get('PULSE_USER')
+    password = os.environ.get('PULSE_PW')
+
+    if user is None and password is None:
+        raise AuthenticationError("PULSE_USER and PULSE_PW are not set.")
+    elif user is None:
+        raise AuthenticationError("PULSE_USER is not set.")
+    elif password is None:
+        raise AuthenticationError("PULSE_PW is not set.")
+
+    return user, password

--- a/pulse_actions/publisher.py
+++ b/pulse_actions/publisher.py
@@ -4,6 +4,10 @@ This module is currently an experiment in publishing messages to pulse.
 It might become a real pulse publisher one day.
 """
 import os
+import sys
+
+from pulse_actions.authentication import (get_user_and_password,
+    AuthenticationError)
 
 from mozillapulse.publishers import GenericPublisher
 from mozillapulse.config import PulseConfiguration
@@ -22,8 +26,11 @@ class MessageHandler:
 
     def __init__(self):
         """Create Publisher."""
-        user  = os.environ.get('PULSE_USER')
-        password = os.environ.get('PULSE_PW')
+        try:
+            user, password = get_user_and_password()
+        except AuthenticationError as e:
+            print(e.message)
+            sys.exit(1)
         self.publisher = ExperimentalPublisher(user=user, password=password)
 
     def publish_message(self, data, routing_key):

--- a/pulse_actions/worker.py
+++ b/pulse_actions/worker.py
@@ -1,7 +1,11 @@
 import json
 import logging
 import os
+import sys
 import traceback
+
+from pulse_actions.authentication import (get_user_and_password,
+    AuthenticationError)
 
 from pulse_actions.handlers import config, route_functions
 from argparse import ArgumentParser
@@ -36,8 +40,12 @@ def run_pulse(exchanges, topics, event_handler, topic_base, dry_run):
         label = topic_base[0]
     else:
         label = str(topic_base)
-    user = os.environ.get('PULSE_USER')
-    password = os.environ.get('PULSE_PW')
+    try:
+        user, password = get_user_and_password()
+    except AuthenticationError as e:
+        print(e.message)
+        sys.exit(1)
+
     pulse_args = {
         'applabel': label,
         'topic': topics,


### PR DESCRIPTION
I've implemented my solution for Bug 1203146[1] by adding a new module for authenticating the user and password, which raises an AuthenticationError if either of them can't be found. I'd like feedback on what I'm doing, like if the structure is good, or if I should go further and ask the user to enter their credentials instead of throwing an error.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1203146
