### PR TITLE
Catching SystemExit

### DIFF
--- a/pulse_actions/worker.py
+++ b/pulse_actions/worker.py
@@ -67,7 +67,7 @@ def run_pulse(exchanges, topics, event_handler, topic_base, dry_run):
     while True:
         try:
             pulse.listen()
-        except Exception as e:
+        except:
             traceback.print_exc()
 
 


### PR DESCRIPTION
Turns out that on the past month, pulse_actions' backfilling worker was turned off almost all the time :-(

mozci raises a SystemExit when it finds an invalid buildername and we were not catching that (except Exception doesn't catch SystemExit). So after a couple of minutes the worker would die with a SystemExit and only be restarted on the next day, when the dyno is restarted.

I know catching a SystemExit is usually not a good idea, but in this case I think it is safe. We want to process each message by itself, and if anything goes wrong processing a message we stop processing it and go to the next one.

r? @armenzg 
