### PR TITLE
Bug 1211659 - Fix backfilling issue with coalesced builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.egg-info/*
+*.swp
 # Packages
 dist
 .idea/

--- a/pulse_actions/handlers/config.py
+++ b/pulse_actions/handlers/config.py
@@ -7,8 +7,14 @@ HANDLERS_BY_EXCHANGE = {
     "exchange/treeherder/v1/job-actions": {
         "manual_backfill": treeherder_buildbot.on_buildbot_event
     },
+    "exchange/treeherder-stage/v1/job-actions": {
+        "manual_backfill-stage": treeherder_buildbot.on_buildbot_event
+    },
     "exchange/treeherder/v1/resultset-actions": {
         "resultset_actions": treeherder_resultset.on_resultset_action_event
+    },
+    "exchange/treeherder-stage/v1/resultset-actions": {
+        "resultset_actions-stage": treeherder_resultset.on_resultset_action_event
     },
     "exchange/build/normalized": {
         "backfilling": backfilling.on_event

--- a/pulse_actions/run_time_config.json
+++ b/pulse_actions/run_time_config.json
@@ -3,8 +3,16 @@
         "exchange": "exchange/treeherder/v1/job-actions",
         "topic": "buildbot.#.backfill"
     },
+    "manual_backfill-stage": {
+        "exchange": "exchange/treeherder-stage/v1/job-actions",
+        "topic": "buildbot.#.backfill"
+    },
     "resultset_actions": {
         "exchange": "exchange/treeherder/v1/resultset-actions",
+        "topic": "#.#"
+    },
+    "resultset_actions-stage": {
+        "exchange": "exchange/treeherder-stage/v1/resultset-actions",
         "topic": "#.#"
     },
     "backfilling":{

--- a/pulse_actions/worker.py
+++ b/pulse_actions/worker.py
@@ -67,6 +67,8 @@ def run_pulse(exchanges, topics, event_handler, topic_base, dry_run):
     while True:
         try:
             pulse.listen()
+        except KeyboardInterrupt:
+            sys.exit(1)
         except:
             traceback.print_exc()
 

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,16 @@
 from setuptools import setup, find_packages
 
 deps = [
-    'mozillapulse>=1.1',
-    'mozci>=0.15.1',
-    'treeherder-client>=1.5',
-    'ijson>=2.2',
-    'requests',
+    'ijson==2.2',
+    'mozci==0.15.1',
+    'MozillaPulse==1.2.1',
+    'requests==2.7.0', # Maximum version taskcluster will work with
+    'taskcluster==0.0.27',
+    'treeherder-client==1.7.0',
 ]
 
 setup(name='pulse-actions',
-      version='0.1.4',
+      version='0.2.0',
       description='A pulse listener that acts upon messages with mozci.',
       classifiers=['Intended Audience :: Developers',
                    'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 deps = [
     'mozillapulse>=1.1',
-    'mozci>=0.14.0',
+    'mozci>=0.15.1',
     'treeherder-client>=1.5',
     'ijson>=2.2',
     'requests',


### PR DESCRIPTION
I will be testing this locally tomorrow morning, push it to Heroku and test on TH's production.

The issue we are facing is that when a backfill is requested and we have coalesced builds,
instead of mozci thinking that we have no build for a push we think that there is a build,
however, what we use is the build with which we got coalesced.

In other words, we were running tests against the wrong build (the one for the most
recent push).

This release of mozci fixes this issue.
