### PR TITLE
Issue 25: Different functions for Treeherder prod and stage

### DIFF
--- a/pulse_actions/handlers/config.py
+++ b/pulse_actions/handlers/config.py
@@ -5,16 +5,16 @@ import pulse_actions.handlers.backfilling as backfilling
 
 HANDLERS_BY_EXCHANGE = {
     "exchange/treeherder/v1/job-actions": {
-        "manual_backfill": treeherder_buildbot.on_buildbot_event
+        "manual_backfill": treeherder_buildbot.on_buildbot_prod_event
     },
     "exchange/treeherder-stage/v1/job-actions": {
-        "manual_backfill-stage": treeherder_buildbot.on_buildbot_event
+        "manual_backfill-stage": treeherder_buildbot.on_buildbot_stage_event
     },
     "exchange/treeherder/v1/resultset-actions": {
-        "resultset_actions": treeherder_resultset.on_resultset_action_event
+        "resultset_actions": treeherder_resultset.on_resultset_action_prod_event
     },
     "exchange/treeherder-stage/v1/resultset-actions": {
-        "resultset_actions-stage": treeherder_resultset.on_resultset_action_event
+        "resultset_actions-stage": treeherder_resultset.on_resultset_action_stage_event
     },
     "exchange/build/normalized": {
         "backfilling": backfilling.on_event

--- a/pulse_actions/worker.py
+++ b/pulse_actions/worker.py
@@ -57,10 +57,6 @@ def run_pulse(exchanges, topics, event_handler, topic_base, dry_run):
     # Pulse consumer's callback passes only data and message arguments
     # to the function, we need to pass dry-run
     def handler_with_dry_run(data, message):
-        # Skip heartbeats until current issue is gone
-        if data.get('payload') and data['payload'].get('what') == 'This is a heartbeat':
-            message.ack()
-            return
         return event_handler(data, message, dry_run)
 
     pulse = PulseConsumer(exchanges,
@@ -95,10 +91,12 @@ def run_exchange_topic(topic_base, dry_run):
     topic_base = topic_base.split(",")
     exchanges = []
     topics = []
+
     for topic in topic_base:
         exchange = options[topic]['exchange']
         exchanges.append(exchange)
         topics.append(options[topic]['topic'])
+
     # Finding the right event handler for the given exchange and topic
     try:
         if len(topic_base) == 1:


### PR DESCRIPTION
This should enable running pulse_actions with both TH prod and TH stage, but not at the same time (because our route_function can't differentiate between stage and production exchanges).
But python worker.py --topic-base=resultset_actions-stage --dry-run should work.

Since I'm not a sheriff on TH-stage, it is a little hard for me to test this. @armenzg would you mind testing this with your special TH powers :-) ?
