### PR TITLE
Update setup.py URL to the Mozilla URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name='pulse-actions',
       include_package_data=True,
       zip_safe=False,
       install_requires=required,
-      url='https://github.com/armenzg/pulse_actions',
+      url='https://github.com/mozilla/pulse_actions',
       entry_points={
           'console_scripts': [
               'run-pulse-actions = pulse_actions.worker:main'


### PR DESCRIPTION
Currently the setup.py URL is /armenzg/pulse_actions. I don't know if we should keep it this way or if it should be /mozilla/pulse_actions.
