### PR TITLE
Improve output of automated backfilling

### DIFF
--- a/pulse_actions/handlers/backfilling.py
+++ b/pulse_actions/handlers/backfilling.py
@@ -13,13 +13,14 @@ This module is for the following use case:
 """
 import logging
 
+from mozci import query_jobs
 from mozci.mozci import (
+    disable_validations,
     find_backfill_revlist,
     trigger_range,
 )
 from mozci.query_jobs import FAILURE, WARNING
 from mozci.sources import buildjson
-from mozci import query_jobs
 from mozci.utils import transfer
 
 LOG = logging.getLogger()
@@ -28,7 +29,7 @@ LOG = logging.getLogger()
 # http://mxr.mozilla.org/build/source/buildbot-configs/mozilla-tests/config_seta.py#9
 # XXX: Fix hardcoding in https://github.com/mozilla/pulse_actions/issues/29
 MAX_REVISIONS = 7
-# Use memory-saving mode
+# This changes the behaviour of mozci in transfer.py
 transfer.MEMORY_SAVING_MODE = True
 
 
@@ -36,6 +37,10 @@ def on_event(data, message, dry_run):
     """Automatically backfill failed jobs."""
     # We need to ack the message to remove it from our queue
     message.ack()
+
+    # Disable mozci's validations
+    # XXX: We only to call this once but for now we will put it here
+    disable_validations()
 
     # Cleaning mozci caches
     buildjson.BUILDS_CACHE = {}

--- a/pulse_actions/handlers/route_functions.py
+++ b/pulse_actions/handlers/route_functions.py
@@ -2,7 +2,6 @@ import pulse_actions.handlers.treeherder_buildbot as treeherder_buildbot
 import pulse_actions.handlers.treeherder_resultset as treeherder_resultset
 import logging
 
-logging.basicConfig(format='%(levelname)s:\t %(message)s')
 LOG = logging.getLogger()
 
 

--- a/pulse_actions/handlers/treeherder_buildbot.py
+++ b/pulse_actions/handlers/treeherder_buildbot.py
@@ -14,7 +14,6 @@ from thclient import TreeherderClient
 
 from pulse_actions.publisher import MessageHandler
 
-logging.basicConfig(format='%(levelname)s:\t %(message)s')
 LOG = logging.getLogger()
 MAX_REVISIONS = 7
 

--- a/pulse_actions/handlers/treeherder_resultset.py
+++ b/pulse_actions/handlers/treeherder_resultset.py
@@ -1,13 +1,16 @@
 import logging
-from mozci.mozci import trigger_missing_jobs_for_revision, trigger_all_talos_jobs
-from thclient import TreeherderClient
-from mozci.sources import buildjson
+
 from mozci import query_jobs
+from mozci.mozci import trigger_missing_jobs_for_revision, trigger_all_talos_jobs
+from mozci.sources import buildjson
+from mozci.utils import transfer
+from thclient import TreeherderClient
 from pulse_actions.publisher import MessageHandler
 
-logging.basicConfig(format='%(levelname)s:\t %(message)s')
 LOG = logging.getLogger()
-MEMORY_SAVING_MODE = True
+# This changes the behaviour of mozci in transfer.py
+transfer.MEMORY_SAVING_MODE = True
+transfer.SHOW_PROGRESS_BAR = False
 
 
 def on_resultset_action_prod_event(data, message, dry_run):

--- a/pulse_actions/worker.py
+++ b/pulse_actions/worker.py
@@ -15,8 +15,7 @@ from pulse_actions.handlers import config, route_functions
 from mozillapulse.config import PulseConfiguration
 from mozillapulse.consumers import GenericConsumer
 
-logging.basicConfig(format='%(levelname)s:\t %(message)s')
-LOG = logging.getLogger()
+LOG = None
 
 
 class PulseConsumer(GenericConsumer):
@@ -75,11 +74,28 @@ def run_pulse(exchanges, topics, event_handler, topic_base, dry_run):
             traceback.print_exc()
 
 
-def load_config():
-    LOG.setLevel(logging.INFO)
+def setup_logging(logging_level):
+    global LOG
+    if LOG:
+        return LOG
+    # Let's use the root logger
+    LOG = logging.getLogger()
+
+    if logging_level == logging.DEBUG:
+        format = '%(asctime)s %(name)s %(levelname)s:\t %(message)s'
+    else:
+        format = '%(levelname)s:\t %(message)s'
+
+    logging.basicConfig(format=format, datefmt='%H:%M:%S')
+    LOG.setLevel(logging_level)
+
+    LOG.info("Setting %s level" % logging.getLevelName(logging_level))
+
     # requests is too noisy
     logging.getLogger("requests").setLevel(logging.WARNING)
 
+
+def load_config():
     current_dir = os.path.dirname(os.path.abspath(__file__))
     config_path = os.path.join(current_dir, 'run_time_config.json')
     with open(config_path, 'r') as config_file:
@@ -126,16 +142,29 @@ def parse_args(argv=None):
                         dest="topic_base",
                         type=str,
                         help="Identifier for exchange and topic to be listened to.")
+
     parser.add_argument("--dry-run",
                         action="store_true",
                         dest="dry_run",
                         help="flag to test without actual push.")
+
+    parser.add_argument("--debug",
+                        action="store_true",
+                        dest="debug",
+                        help="set debug for logging.")
+
     options = parser.parse_args(argv)
     return options
 
 
 def main():
     options = parse_args()
+
+    if options.debug:
+        setup_logging(logging.DEBUG)
+    else:
+        setup_logging(logging.INFO)
+
     run_exchange_topic(options.topic_base, options.dry_run)
 
 


### PR DESCRIPTION
- Allow worker.py to be called with debug log levels
- Fix logging.basicConfig() in worker.py by removing it from all
  imported modules (it prevented changing the formatter)
- Enable memory saving mode, disable progress bar and mozci validations
  at the worker level
