### PR TITLE
Update treeherder-client from 1.7.0 to 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,17 +2,20 @@ amqp==1.4.7
 anyjson==0.3.3
 beautifulsoup4==4.4.1
 bugsy==0.6.0
-httplib2==0.9.2
 ijson==2.2
 keyring==5.4
 kombu==3.0.26
 mozci==0.23.2
 MozillaPulse==1.2.2
-oauth2==1.9.0.post1
 progressbar==2.3
 PyHawk-with-a-single-extra-commit==0.1.5
 pytz==2015.6
 requests==2.7.0
 slugid==1.0.6
 taskcluster==0.0.29
-treeherder-client==1.7.0
+treeherder-client==2.0.1
+
+# Required by treeherder-client
+mohawk==0.3.1
+requests-hawk==1.0.0
+six==1.10.0


### PR DESCRIPTION
It now requires mohawk/requests-hawk/six, and no longer requires oauth2 and httplib2. The sub-dependencies have been separated to make it easier to spot orphaned dependencies in the future.
