### PR TITLE
Add requires.io badge for tracking python requirements status

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 .. image:: https://travis-ci.org/mozilla/pulse_actions.svg?branch=master
     :target: https://travis-ci.org/mozilla/pulse_actions
     :alt: Travis-CI Build Status
+.. image:: https://requires.io/github/mozilla/pulse_actions/requirements.svg?branch=master
+     :target: https://requires.io/github/mozilla/pulse_actions/requirements/?branch=master
+     :alt: Requirements Status
 
 =============
 Pulse Actions


### PR DESCRIPTION
Requires.io also optionally allows you to receive email notifications and even PRs for updating dependencies (either just for security-critical updates or all of them), but I'll leave that for someone else to explore another day :-)
