### PR TITLE
Handlers do not guarantee a numeric exit code; work around it

### DIFF
--- a/pulse_actions/worker.py
+++ b/pulse_actions/worker.py
@@ -260,10 +260,6 @@ def end_request(exit_code, data, log_path, treeherder_job, start_time):
         url = S3_UPLOADER.upload(log_path)
         LOG.debug('Log uploaded to {}'.format(url))
 
-        # XXX: Do something more elegant
-        if exit_code is None:
-            exit_code = 0
-
         JOB_FACTORY.submit_completed(
             job=treeherder_job,
             result=EXIT_CODE_JOB_RESULT_MAP[exit_code],
@@ -339,7 +335,11 @@ def route(data, message, **kwargs):
         # 3) Submit results to Treeherder
         end_request(exit_code=exit_code, data=data, **end_request_kwargs)
 
-    assert exit_code is not None and type(exit_code) == int
+    # XXX: Do something more elegant
+    if exit_code is None:
+        exit_code = 0
+
+    assert type(exit_code) == int
 
     return exit_code
 

--- a/pulse_actions/worker.py
+++ b/pulse_actions/worker.py
@@ -332,14 +332,14 @@ def route(data, message, **kwargs):
         exit_code = handler(data=data, message=message, repo_name=repo_name,
                             revision=revision, **kwargs)
 
+        # XXX: Until handlers can guarantee an exit_code
+        if exit_code is None:
+            exit_code = 0
+
         # 3) Submit results to Treeherder
         end_request(exit_code=exit_code, data=data, **end_request_kwargs)
 
-    # XXX: Do something more elegant
-    if exit_code is None:
-        exit_code = 0
-
-    assert type(exit_code) == int
+    assert exit_code is not None and type(exit_code) == int
 
     return exit_code
 


### PR DESCRIPTION
We currently don't have a safe guard for handlers to have a numeric exit code but they can return None.

In this patch we work around it until we can fix it.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/pulse_actions/96)

<!-- Reviewable:end -->
