### PR TITLE
Improving checks to identify TaskCluster ref names

### DIFF
--- a/pulse_actions/handlers/treeherder_add_new_jobs.py
+++ b/pulse_actions/handlers/treeherder_add_new_jobs.py
@@ -9,7 +9,7 @@ from pulse_actions.utils.misc import (
 from mozci import TaskClusterBuildbotManager, query_jobs
 from mozci.mozci import trigger_job
 from mozci.sources import buildjson, buildbot_bridge
-from mozci.taskcluster import TaskClusterManager
+from mozci.taskcluster import TaskClusterManager, is_taskcluster_label
 from thclient import TreeherderClient
 
 LOG = logging.getLogger(__name__.split('.')[-1])
@@ -72,7 +72,7 @@ def on_event(data, message, dry_run, treeherder_server_url, acknowledge, **kwarg
         LOG.info("- %s" % b)
 
     # Handle TC tasks separately
-    task_labels = [x for x in requested_jobs if x.startswith('TaskLabel==')]
+    task_labels = [x for x in requested_jobs if is_taskcluster_label(x, decision_task_id)]
     buildernames = list(set(requested_jobs) - set(task_labels))
 
     buildernames = filter_invalid_builders(buildernames)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Main dependencies
-mozci==0.43.1
+mozci==0.44.0
 pulse_replay==0.2.2
 treeherder_submitter==0.4.1
 taskcluster_s3_uploader==0.3.1


### PR DESCRIPTION
This should be merged after the corresponding mozci fix

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/pulse_actions/107)

<!-- Reviewable:end -->
