### PR TITLE
Separate Buildbot/TaskCluster scheduling into different functions

### DIFF
--- a/pulse_actions/handlers/treeherder_add_new_jobs.py
+++ b/pulse_actions/handlers/treeherder_add_new_jobs.py
@@ -28,31 +28,18 @@ def on_event(data, message, dry_run, treeherder_server_url, acknowledge, **kwarg
             message.ack()
         return 0  # SUCCESS
 
-    # Cleaning mozci caches
-    buildjson.BUILDS_CACHE = {}
-    query_jobs.JOBS_CACHE = {}
-
-    treeherder_client = TreeherderClient(server_url=treeherder_server_url)
-
     # Grabbing data received over pulse
     repo_name = data["project"]
     requester = data["requester"]
     resultset_id = data["resultset_id"]
-    if "buildernames" in data:
-        requested_jobs = data["buildernames"]
-    elif "requested_jobs" in data:
+
+    if "requested_jobs" in data:
         requested_jobs = data["requested_jobs"]
     else:
         LOG.error("Appropriate job requests not found in the pulse message.")
         return -1
 
-    # This is empty strings in non-try pulse messages
-    # Remove support for `decisionTaskID` once bug 1286897 fixed.
-    decision_task_id = data.get('decision_task_id', data.get('decisionTaskID'))
-    if not decision_task_id:
-        LOG.error('The pulse message did not contain the decision task ID.')
-        return -1
-
+    treeherder_client = TreeherderClient(server_url=treeherder_server_url)
     resultset = treeherder_client.get_resultsets(repo_name, id=resultset_id)[0]
     revision = resultset["revision"]
     author = resultset["author"]
@@ -61,6 +48,12 @@ def on_event(data, message, dry_run, treeherder_server_url, acknowledge, **kwarg
         'treeherder_server_url': treeherder_server_url,
         'repo': repo_name,
         'revision': resultset['revision']
+    }
+    metadata = {
+        'name': 'pulse_actions_graph',
+        'description': 'Adding new jobs to push via pulse_actions/treeherder for %s.' % requester,
+        'owner': requester,
+        'source': treeherder_link,
     }
 
     if not (requester.endswith('@mozilla.com') or author == requester or
@@ -72,17 +65,41 @@ def on_event(data, message, dry_run, treeherder_server_url, acknowledge, **kwarg
 
     LOG.info("New jobs requested by %s for %s" % (requester, treeherder_link))
     LOG.info("List of requested jobs:")
-    for b in requested_jobs:
-        LOG.info("- %s" % b)
+    for job in requested_jobs:
+        LOG.info("- {}".format(job))
 
-    # Handle TC tasks separately
+    # This is empty strings in non-try pulse messages
+    # Remove support for `decisionTaskID` once bug 1286897 fixed.
+    decision_task_id = data.get('decision_task_id', data.get('decisionTaskID'))
+
+    # Separate Buildbot buildernames from TaskCluster task labels
     if decision_task_id:
         task_labels = [x for x in requested_jobs if is_taskcluster_label(x, decision_task_id)]
     else:
         task_labels = []
-    buildernames = list(set(requested_jobs) - set(task_labels))
 
-    buildernames = filter_invalid_builders(buildernames)
+    # Treeherder can send us invalid builder names
+    # https://bugzilla.mozilla.org/show_bug.cgi?id=1242038
+    buildernames = filter_invalid_builders(list(set(requested_jobs) - set(task_labels)))
+
+    # XXX: In the future handle return codes
+    add_taskcluster_jobs(task_labels, decision_task_id, repo_name)
+    add_buildbot_jobs(repo_name, revision, buildernames, metadata, dry_run)
+
+    if acknowledge:
+        # We need to ack the message to remove it from our queue
+        message.ack()
+
+    return 0  # SUCCESS
+
+
+def add_taskcluster_jobs(task_labels, decision_task_id, repo_name, dry_run):
+    if not decision_task_id:
+        LOG.warning("The pulse message did not contain the decision task ID."
+                    "We can't schedule TaskCluster jobs.")
+        # We don't raise an exception because we hope that the Buildbot jobs (if any)
+        # will get scheduled.
+        return -1
 
     # Scheduling TaskCluster jobs
     # Make sure that decision task id is not null and task_labels are there to schedule
@@ -98,16 +115,23 @@ def on_event(data, message, dry_run, treeherder_server_url, acknowledge, **kwarg
                 mgr = TaskClusterManager(dry_run=dry_run)
                 mgr.schedule_action_task(decision_task_id=decision_task_id,
                                          task_labels=task_labels)
-            except Exception, e:
+            except Exception as e:
+                # XXX: Read the following article and determine if we need to improve this
+                # https://www.loggly.com/blog/exceptional-logging-of-exceptions-in-python
                 LOG.warning(str(e))
-                raise
+                # We don't raise the exception since we hope that at least the Buildbot
+                # jobs can be schedule
+                return -1
 
-    # Treeherder can send us invalid builder names
-    # https://bugzilla.mozilla.org/show_bug.cgi?id=1242038
-    if buildernames is None:
-        if acknowledge:
-            # We need to ack the message to remove it from our queue
-            message.ack()
+    return 0  # No issues were found
+
+
+def add_buildbot_jobs(repo_name, revision, buildernames, metadata, dry_run):
+    # Cleaning mozci caches
+    buildjson.BUILDS_CACHE = {}
+    query_jobs.JOBS_CACHE = {}
+
+    if not buildernames:
         return -1  # FAILURE
 
     builders_graph, other_builders_to_schedule = buildbot_bridge.buildbot_graph_builder(
@@ -121,13 +145,7 @@ def on_event(data, message, dry_run, treeherder_server_url, acknowledge, **kwarg
         mgr.schedule_graph(
             repo_name=repo_name,
             revision=revision,
-            metadata={
-                'name': 'pulse_actions_graph',
-                'description':
-                    'Adding new jobs to push via pulse_actions/treeherder for %s.' % requester,
-                'owner': requester,
-                'source': treeherder_link,
-            },
+            metadata=metadata,
             builders_graph=builders_graph,
             dry_run=dry_run)
     else:
@@ -143,9 +161,3 @@ def on_event(data, message, dry_run, treeherder_server_url, acknowledge, **kwarg
             trigger_job(revision, buildername, dry_run=dry_run)
     else:
         LOG.info("We don't have anything to schedule through Buildapi")
-
-    if acknowledge:
-        # We need to ack the message to remove it from our queue
-        message.ack()
-
-    return 0  # SUCCESS


### PR DESCRIPTION
It also makes certain errors to not raise exception, thus, allowing
other scheduling to succeed.

It also makes requests without a decision task ID to get stuck in the
queue.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/pulse_actions/112)

<!-- Reviewable:end -->
